### PR TITLE
feat: add find api for using roc mango queries

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -50,7 +50,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [12.x, 14.x, 16.x]
+        node-version: [14.x, 16.x, 18.x]
     steps:
       - uses: actions/checkout@v2
       - name: Use Node.js ${{ matrix.node-version }}

--- a/rest-on-couch/Dockerfile
+++ b/rest-on-couch/Dockerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/cheminfo/rest-on-couch:12
+FROM ghcr.io/cheminfo/rest-on-couch:13
 
 # Install system packages
 RUN apt-get update && apt-get install -y vim

--- a/rest-on-couch/home/test/indexes/id.js
+++ b/rest-on-couch/home/test/indexes/id.js
@@ -1,0 +1,15 @@
+'use strict';
+
+module.exports = {
+  id: {
+    index: {
+      fields: [
+        {
+          '\\$id': 'asc',
+        },
+      ],
+    },
+    type: 'json',
+    ddoc: 'idIndex',
+  },
+};

--- a/rest-on-couch/start.sh
+++ b/rest-on-couch/start.sh
@@ -1,5 +1,6 @@
-#!/usr/bin/env sh
+#!/usr/bin/env bash
 
 /create_db.sh
 
-node /rest-on-couch-source/bin/rest-on-couch-server.js
+https://unix.stackexchange.com/a/196053/116499
+exec node /rest-on-couch-source/bin/rest-on-couch-server.js

--- a/rest-on-couch/start.sh
+++ b/rest-on-couch/start.sh
@@ -2,5 +2,5 @@
 
 /create_db.sh
 
-https://unix.stackexchange.com/a/196053/116499
+# https://unix.stackexchange.com/a/196053/116499
 exec node /rest-on-couch-source/bin/rest-on-couch-server.js

--- a/src/roc/Find.ts
+++ b/src/roc/Find.ts
@@ -1,0 +1,47 @@
+import { AxiosInstance } from 'axios';
+
+import {
+  IFindOptions,
+  IFindQueryResult,
+  PromisedFindQueryResult,
+  RocAxiosRequestOptions,
+} from '../types';
+
+export default class Find<ResultType> {
+  public readonly viewName: string;
+  protected baseOptions: IFindOptions;
+  private request: AxiosInstance;
+  public constructor(options: IFindOptions, request: AxiosInstance) {
+    this.request = request;
+    this.baseOptions = options;
+  }
+
+  public then(
+    resolve: (value: IFindQueryResult<ResultType>) => void,
+    reject: (error: Error) => void,
+  ) {
+    this.fetch<ResultType>().then(resolve, reject);
+  }
+
+  public async fetch<ResultType>(
+    options: IFindOptions = {},
+    axiosOptions?: RocAxiosRequestOptions,
+  ): PromisedFindQueryResult<ResultType> {
+    const findOptions = {
+      ...this.baseOptions,
+      ...options,
+      query: {
+        ...this.baseOptions.query,
+        ...options.query,
+      },
+    };
+
+    const response = await this.request({
+      method: 'POST',
+      url: '_find',
+      data: findOptions,
+      ...axiosOptions,
+    });
+    return response.data;
+  }
+}

--- a/src/roc/Query.ts
+++ b/src/roc/Query.ts
@@ -37,7 +37,7 @@ export default class Query<KeyType, ValueType, ContentType> {
     const params = Object.assign({}, this.baseOptions, options);
 
     const response = await this.request({
-      url: '/',
+      url: `_query/${this.viewName}`,
       params,
       ...axiosOptions,
     });

--- a/src/roc/Roc.ts
+++ b/src/roc/Roc.ts
@@ -4,6 +4,7 @@ import { ICouchGroupInfo, IEntryDocument } from '..';
 import {
   ICouchUser,
   ICouchUserGroup,
+  IFindOptions,
   IGroupDocument,
   INewEntryDocument,
   IQueryOptions,
@@ -13,6 +14,7 @@ import {
   RocAxiosRequestOptions,
 } from '../types';
 
+import Find from './Find';
 import Query from './Query';
 import ReduceQuery from './ReduceQuery';
 import RocDocument, { RocDocumentOptions } from './RocDocument';
@@ -112,11 +114,12 @@ export default class Roc<PublicUserInfo = unknown, PrivateUserInfo = unknown> {
     return new Query<KeyType, ValueType, ContentType>(
       viewName,
       options,
-      createAxios(
-        new URL(`_query/${viewName}`, this.dbUrl).href,
-        this.accessToken,
-      ),
+      this.dbRequest,
     );
+  }
+
+  public getFind<ResultType = unknown>(options: IFindOptions) {
+    return new Find<ResultType>(options, this.dbRequest);
   }
 
   public getReduceQuery<KeyType = unknown, ValueType = unknown>(

--- a/src/roc/__tests__/find.ts
+++ b/src/roc/__tests__/find.ts
@@ -1,0 +1,58 @@
+import {
+  getNewDocument,
+  getNewEntry,
+  resetTestDatabase,
+  testRoc,
+} from '../../testUtils';
+
+beforeAll(async () => {
+  await resetTestDatabase();
+});
+
+test('getFind', async () => {
+  await testRoc.create(getNewEntry('id1'));
+  await testRoc.create(getNewEntry('id2'));
+  await testRoc.create(getNewDocument('otherKind', 'id3'));
+
+  const find = testRoc.getFind({
+    right: 'read',
+    query: { limit: 2 },
+  });
+
+  const data = await find.fetch<{ $kind: string }>({
+    query: { fields: ['$kind'] },
+  });
+  expect(data.docs).toHaveLength(2);
+});
+
+test('getFind with custom right, selector and sort', async () => {
+  await testRoc.create(getNewEntry('id4'));
+
+  const find = testRoc.getFind({
+    right: 'owner',
+    query: {
+      limit: 2,
+      selector: {
+        '\\$id': {
+          $gte: 'id1',
+          $lte: 'id3',
+        },
+      },
+      sort: [{ '\\$id': 'desc' }],
+      use_index: 'id',
+    },
+  });
+
+  const data = await find.fetch<{ $id: string }>({
+    query: { fields: ['$id'] },
+  });
+  expect(data.docs).toHaveLength(2);
+  expect(data.docs).toStrictEqual([{ $id: 'id3' }, { $id: 'id2' }]);
+});
+
+test('getFind thenable', async () => {
+  const data = await testRoc.getFind<{ $kind: string }>({
+    query: { limit: 3 },
+  });
+  expect(data.docs).toHaveLength(3);
+});

--- a/src/testUtils.ts
+++ b/src/testUtils.ts
@@ -55,12 +55,12 @@ export const testRoc = new Roc({
 
 type TestNewDoc = INewEntryDocument<{ hello: 'world' }, string>;
 
-export function getNewEntry(id: string) {
+export function getNewEntry(id: string, groups?: string[]) {
   return {
     $id: id,
     $kind: 'entry',
     $content: { hello: 'world' },
-    $owners: [],
+    $owners: groups ?? [],
   } as TestNewDoc;
 }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -194,6 +194,24 @@ export type PromisedReduceQueryResult<KeyType, ValueType> = Promise<
   Array<IReduceQueryResult<KeyType, ValueType>>
 >;
 
+export type PromisedFindQueryResult<ResultType> = Promise<
+  IFindQueryResult<ResultType>
+>;
+
+export interface IFindQueryResult<ResultType> {
+  docs: Array<ResultType>;
+  warning?: string;
+  execution_status?: IFindExecutionStatus;
+  bookmark?: string;
+}
+
+interface IFindExecutionStatus {
+  total_keys_examined: number;
+  total_docs_examined: number;
+  total_quorum_docs_examined: number;
+  results_returned: number;
+  execution_time_ms: number;
+}
 export interface ICouchUser {
   username: string;
   admin: boolean;
@@ -222,3 +240,22 @@ export type RocAxiosRequestOptions = Pick<
   AxiosRequestConfig,
   'signal' | 'timeout' | 'timeoutErrorMessage'
 >;
+
+export interface IFindOptions {
+  right?: GroupRight;
+  mine?: boolean;
+  group?: string;
+  query?: ICouchMangoQueryOptions;
+}
+
+export interface ICouchMangoQueryOptions {
+  selector?: object;
+  fields?: string[];
+  limit?: number;
+  bookmark?: string;
+  skip?: number;
+  sort?: Array<string> | Array<Record<string, 'asc' | 'desc'>>;
+  use_index?: string;
+  update?: boolean;
+  execution_stats?: boolean;
+}


### PR DESCRIPTION
- feat: add roc.getFind to query with mango
- chore: segue into rest-on-couch process from bash process
- chore: upgrade to rest-on-couch v13
