### PR TITLE
fix: percent-encode attachment names in URLs

### DIFF
--- a/src/roc/RocDocument.ts
+++ b/src/roc/RocDocument.ts
@@ -10,7 +10,11 @@ import type {
 import type { EntryDocumentDraft } from '../types_internal.ts';
 import { assert } from '../util/assert.ts';
 
-import { addInlineUploads, deleteInlineUploads } from './utils.ts';
+import {
+  addInlineUploads,
+  deleteInlineUploads,
+  encodeAttachmentName,
+} from './utils.ts';
 
 export interface RocDocumentOptions {
   allowAttachmentOverwrite: boolean;
@@ -52,7 +56,7 @@ export class RocDocument<
     responseType: 'text' | 'arraybuffer' | 'blob',
     axiosOptions?: RocAxiosRequestOptions,
   ): Promise<Buffer | string> {
-    const response = await this.request.get(name, {
+    const response = await this.request.get(encodeAttachmentName(name), {
       responseType,
       ...axiosOptions,
     });
@@ -160,7 +164,7 @@ export class RocDocument<
     return {
       ...attachments[name],
       name,
-      url: this.request.getUri({ url: name }),
+      url: this.request.getUri({ url: encodeAttachmentName(name) }),
     };
   }
 

--- a/src/roc/__tests__/utils.test.ts
+++ b/src/roc/__tests__/utils.test.ts
@@ -1,0 +1,23 @@
+import { expect, test } from 'vitest';
+
+import { encodeAttachmentName } from '../utils.ts';
+
+test('leaves a plain name unchanged', () => {
+  expect(encodeAttachmentName('test.txt')).toBe('test.txt');
+});
+
+test('encodes a literal + as %2B', () => {
+  expect(encodeAttachmentName('MJR_RuPt_RuPt1+hv(long).1.28a2b17f.jdx')).toBe(
+    'MJR_RuPt_RuPt1%2Bhv(long).1.28a2b17f.jdx',
+  );
+});
+
+test('encodes spaces as %20', () => {
+  expect(encodeAttachmentName('with space.jdx')).toBe('with%20space.jdx');
+});
+
+test('preserves / separators while encoding each segment', () => {
+  expect(encodeAttachmentName('nested/dir/a+b.txt')).toBe(
+    'nested/dir/a%2Bb.txt',
+  );
+});

--- a/src/roc/utils.ts
+++ b/src/roc/utils.ts
@@ -7,6 +7,19 @@ import type {
 } from '../types_internal.ts';
 import { assert } from '../util/assert.ts';
 
+/**
+ * Percent-encodes an attachment name for use in a request URL.
+ * Each path segment is encoded individually so that `/` separators are kept,
+ * while characters like `+` or spaces become `%2B` / `%20`. Without this, a
+ * literal `+` in a filename reaches the server unencoded and is decoded back
+ * to a space, so the attachment is not found.
+ * @param name - The attachment name (may contain `/`).
+ * @returns The encoded name safe to append to the document URL.
+ */
+export function encodeAttachmentName(name: string): string {
+  return name.split('/').map(encodeURIComponent).join('/');
+}
+
 export async function addInlineUploads<ContentType, IdType>(
   entry: EntryDocumentDraft<ContentType, IdType>,
   attachments: RocNewAttachment[],


### PR DESCRIPTION
A filename containing a literal `+` (e.g. `MJR_RuPt_RuPt1+hv(long).1.28a2b17f.jdx`) reached the server unencoded, where it was decoded back to a space, so the attachment could not be found — NMRium failed to load such JCAMP files.

`getAttachment().url` and `fetchAttachment()` passed the raw name to axios, which does not encode the URL path. Now each path segment is run through `encodeURIComponent` (`+` → `%2B`, space → `%20`), keeping `/` separators intact.

This should solved: 
- https://github.com/cheminfo/eln.epfl.ch/issues/1172
Once available in scipeaks-react